### PR TITLE
Add album model

### DIFF
--- a/assets/albums.json
+++ b/assets/albums.json
@@ -1,11 +1,20 @@
 [
     {
-        "title": "FEARLESS"
+        "title": "FEARLESS",
+        "releaseDate": "2022-05-02",
+        "lyricsFolderPath": "",
+        "lyricsPaths": []
     },
     {
-        "title": "ANTIFRAGILE"
+        "title": "ANTIFRAGILE",
+        "releaseDate": "2022-10-17",
+        "lyricsFolderPath": "",
+        "lyricsPaths": []
     },
     {
-        "title": "UNFORGIVEN"
+        "title": "UNFORGIVEN",
+        "releaseDate": "2023-05-01",
+        "lyricsFolderPath": "",
+        "lyricsPaths": []
     }
 ]

--- a/lib/model/album.dart
+++ b/lib/model/album.dart
@@ -1,0 +1,27 @@
+class Album {
+  final String title;
+  final DateTime releaseDate;
+  final String? imagePath;
+  final String lyricsFolderPath;
+  final List<String> lyricsPaths;
+
+  Album({
+    required this.title,
+    required this.releaseDate,
+    required this.imagePath,
+    required this.lyricsFolderPath,
+    required this.lyricsPaths,
+  });
+
+  factory Album.fromJson(Map<String, dynamic> json) {
+    return Album(
+      title: json['title'] as String,
+      releaseDate: DateTime.parse(json['releaseDate'] as String),
+      imagePath: json['imagePath'] as String?,
+      lyricsFolderPath: json['lyricsFolderPath'] as String,
+      lyricsPaths: List<String>.from(
+        (json['lyricsPaths'] as Iterable).map((path) => path as String),
+      ),
+    );
+  }
+}

--- a/lib/ui/album_page.dart
+++ b/lib/ui/album_page.dart
@@ -1,18 +1,19 @@
 import 'package:flutter/material.dart';
+import 'package:lesserafim_lyrics/model/album.dart';
 
 class AlbumPage extends StatelessWidget {
-  final String title;
+  final Album album;
 
   const AlbumPage({
     super.key,
-    required this.title,
+    required this.album,
   });
 
   @override
   Widget build(BuildContext context) {
     return Scaffold(
       appBar: AppBar(
-        title: Text(title),
+        title: Text(album.title),
       ),
     );
   }

--- a/lib/ui/home.dart
+++ b/lib/ui/home.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:lesserafim_lyrics/model/album.dart';
 import 'dart:convert';
 
 import 'package:lesserafim_lyrics/ui/album_page.dart';
@@ -21,11 +22,13 @@ class Home extends StatelessWidget {
       body: FutureBuilder(
         future: DefaultAssetBundle.of(context).loadString('assets/albums.json'),
         builder: (context, snapshot) {
-          var lyrics = json.decode(snapshot.data.toString());
+          final lyrics = json.decode(snapshot.data.toString());
 
           return ListView.builder(
             itemCount: lyrics == null ? 0 : lyrics.length,
             itemBuilder: (context, index) {
+              final album = Album.fromJson(lyrics[index]);
+
               return Card(
                 clipBehavior: Clip.hardEdge,
                 child: InkWell(
@@ -34,15 +37,13 @@ class Home extends StatelessWidget {
                       context,
                       MaterialPageRoute(
                         builder: (context) => AlbumPage(
-                          title: lyrics[index]["title"],
+                          album: album,
                         ),
                       ),
                     );
                   },
                   child: ListTile(
-                    title: Text(
-                      lyrics[index]["title"],
-                    ),
+                    title: Text(album.title),
                   ),
                 ),
               );


### PR DESCRIPTION
- Created `Album` at `model/album.dart`.
- Included a `fromJson` factory method.
- Refactor code to use `Album` model.