### PR TITLE
Add song model

### DIFF
--- a/assets/albums.json
+++ b/assets/albums.json
@@ -2,19 +2,39 @@
     {
         "title": "FEARLESS",
         "releaseDate": "2022-05-02",
-        "lyricsFolderPath": "",
-        "lyricsPaths": []
+        "lyricsFolderPath": "assets/lyrics/fearless",
+        "lyricsPaths": [
+            "the_world_is_my_oyster.json",
+            "fearless.json",
+            "blue_flame.json",
+            "the_great_mermaid.json",
+            "sour_grapes.json"
+        ]
     },
     {
         "title": "ANTIFRAGILE",
         "releaseDate": "2022-10-17",
-        "lyricsFolderPath": "",
-        "lyricsPaths": []
+        "lyricsFolderPath": "assets/lyrics/antifragile",
+        "lyricsPaths": [
+            "the_hydra.json",
+            "antifragile.json",
+            "impurities.json",
+            "no_celestial.json",
+            "good_parts_when_the_quality_is_bad_but_i_am.json"
+        ]
     },
     {
         "title": "UNFORGIVEN",
         "releaseDate": "2023-05-01",
-        "lyricsFolderPath": "",
-        "lyricsPaths": []
+        "lyricsFolderPath": "assets/lyrics/unforgiven",
+        "lyricsPaths": [
+            "burn_the_bridge.json",
+            "unforgiven_feat_nile_rodgers.json",
+            "no_return_into_the_unknown.json",
+            "eve_psyche_and_the_bluebeards_wife.json",
+            "fearnot_between_you_me_and_the_lamppost.json",
+            "flash_forward.json",
+            "fire_in_the_belly.json"
+        ]
     }
 ]

--- a/assets/lyrics/antifragile/antifragile.json
+++ b/assets/lyrics/antifragile/antifragile.json
@@ -1,0 +1,4 @@
+{
+    "title": "ANTIFRAGILE",
+    "lyrics": {}
+}

--- a/assets/lyrics/antifragile/good_parts_when_the_quality_is_bad_but_i_am.json
+++ b/assets/lyrics/antifragile/good_parts_when_the_quality_is_bad_but_i_am.json
@@ -1,0 +1,4 @@
+{
+    "title": "Good Parts (when the quality is bad but I am)",
+    "lyrics": {}
+}

--- a/assets/lyrics/antifragile/impurities.json
+++ b/assets/lyrics/antifragile/impurities.json
@@ -1,0 +1,4 @@
+{
+    "title": "Impurities",
+    "lyrics": {}
+}

--- a/assets/lyrics/antifragile/no_celestial.json
+++ b/assets/lyrics/antifragile/no_celestial.json
@@ -1,0 +1,4 @@
+{
+    "title": "No Celestial",
+    "lyrics": {}
+}

--- a/assets/lyrics/antifragile/the_hydra.json
+++ b/assets/lyrics/antifragile/the_hydra.json
@@ -1,0 +1,4 @@
+{
+    "title": "The Hydra",
+    "lyrics": {}
+}

--- a/assets/lyrics/fearless/blue_flame.json
+++ b/assets/lyrics/fearless/blue_flame.json
@@ -1,0 +1,4 @@
+{
+    "title": "Blue Flame",
+    "lyrics": {}
+}

--- a/assets/lyrics/fearless/fearless.json
+++ b/assets/lyrics/fearless/fearless.json
@@ -1,0 +1,4 @@
+{
+    "title": "FEARLESS",
+    "lyrics": {}
+}

--- a/assets/lyrics/fearless/sour_grapes.json
+++ b/assets/lyrics/fearless/sour_grapes.json
@@ -1,0 +1,4 @@
+{
+    "title": "Sour Grapes",
+    "lyrics": {}
+}

--- a/assets/lyrics/fearless/the_great_mermaid.json
+++ b/assets/lyrics/fearless/the_great_mermaid.json
@@ -1,0 +1,4 @@
+{
+    "title": "The Great Mermaid",
+    "lyrics": {}
+}

--- a/assets/lyrics/fearless/the_world_is_my_oyster.json
+++ b/assets/lyrics/fearless/the_world_is_my_oyster.json
@@ -1,0 +1,4 @@
+{
+    "title": "The World Is My Oyster",
+    "lyrics": {}
+}

--- a/assets/lyrics/unforgiven/burn_the_bridge.json
+++ b/assets/lyrics/unforgiven/burn_the_bridge.json
@@ -1,0 +1,4 @@
+{
+    "title": "Burn the Bridge",
+    "lyrics": {}
+}

--- a/assets/lyrics/unforgiven/eve_psyche_and_the_bluebeards_wife.json
+++ b/assets/lyrics/unforgiven/eve_psyche_and_the_bluebeards_wife.json
@@ -1,0 +1,4 @@
+{
+    "title": "Eve, Psyche & The Bluebeard's wife",
+    "lyrics": {}
+}

--- a/assets/lyrics/unforgiven/fearnot_between_you_me_and_the_lamppost.json
+++ b/assets/lyrics/unforgiven/fearnot_between_you_me_and_the_lamppost.json
@@ -1,0 +1,4 @@
+{
+    "title": "FEARNOT (Between you, me and the lamppost)",
+    "lyrics": {}
+}

--- a/assets/lyrics/unforgiven/fire_in_the_belly.json
+++ b/assets/lyrics/unforgiven/fire_in_the_belly.json
@@ -1,0 +1,4 @@
+{
+    "title": "Fire in the belly",
+    "lyrics": {}
+}

--- a/assets/lyrics/unforgiven/flash_forward.json
+++ b/assets/lyrics/unforgiven/flash_forward.json
@@ -1,0 +1,4 @@
+{
+    "title": "Flash Forward",
+    "lyrics": {}
+}

--- a/assets/lyrics/unforgiven/no_return_into_the_unknown.json
+++ b/assets/lyrics/unforgiven/no_return_into_the_unknown.json
@@ -1,0 +1,4 @@
+{
+    "title": "No-Return (Into the unknown)",
+    "lyrics": {}
+}

--- a/assets/lyrics/unforgiven/unforgiven_feat_nile_rodgers.json
+++ b/assets/lyrics/unforgiven/unforgiven_feat_nile_rodgers.json
@@ -1,0 +1,4 @@
+{
+    "title": "UNFORGIVEN (feat. Nile Rodgers)",
+    "lyrics": {}
+}

--- a/lib/model/song.dart
+++ b/lib/model/song.dart
@@ -1,0 +1,73 @@
+class Song {
+  final String title;
+  final Map<String, List<String>> lyrics;
+
+  Song({
+    required this.title,
+    required this.lyrics,
+  }) : assert(
+          lineCountMatch(lyrics),
+          'Song lyrics for "$title" must have matching number of lines.'
+          '\n'
+          '\n'
+          'The length of each set of lyrics are as follows'
+          '\n'
+          '\n'
+          '${_lyricLengths(lyrics)}'
+          '\n'
+          '\n'
+          'The lyrics have has section indices'
+          '\n'
+          '\n'
+          '${_sectionIndices(lyrics)}'
+          '\n',
+        );
+
+  static bool lineCountMatch(Map<String, List<String>> lyrics) {
+    List<MapEntry> entries = lyrics.entries.toList();
+
+    for (int i = 1; i < entries.length; i++) {
+      for (int j = 0; j < i; j++) {
+        if (entries[i].value?.length != entries[j].value?.length) {
+          return false;
+        }
+      }
+    }
+
+    return true;
+  }
+
+  factory Song.fromJson(Map<String, dynamic> json) {
+    return Song(
+      title: '${json['title']}',
+      lyrics: Map<String, List<dynamic>>.from(json['lyrics'])
+          .map((key, list) => MapEntry(key, List<String>.from(list))),
+    );
+  }
+
+  /// Returns the number of lines for each
+  /// section of a given set of lyrics
+  static String _sectionIndices(Map<String, List<String>> lyrics) {
+    return lyrics
+        .map((k, v) {
+          List<int> indices = [];
+          int i = 0;
+          while (i < v.length) {
+            if (v.elementAt(i).isEmpty ||
+                (v.elementAt(i).startsWith('[') &&
+                    v.elementAt(i).endsWith(']'))) {
+              indices.add(i);
+            }
+            i++;
+          }
+          return MapEntry(k, '$indices');
+        })
+        .entries
+        .map((e) => '${e.key}: ${e.value}')
+        .join('\n');
+  }
+
+  static Map<String, int> _lyricLengths(Map<String, List<String>> lyrics) {
+    return lyrics.map((key, value) => MapEntry(key, value.length));
+  }
+}

--- a/lib/ui/album_page.dart
+++ b/lib/ui/album_page.dart
@@ -1,5 +1,8 @@
+import 'dart:convert';
+
 import 'package:flutter/material.dart';
 import 'package:lesserafim_lyrics/model/album.dart';
+import 'package:lesserafim_lyrics/model/song.dart';
 
 class AlbumPage extends StatelessWidget {
   final Album album;
@@ -15,6 +18,29 @@ class AlbumPage extends StatelessWidget {
       appBar: AppBar(
         title: Text(album.title),
       ),
+      body: ListView.custom(
+        childrenDelegate: SliverChildBuilderDelegate(
+          childCount: album.lyricsPaths.length,
+          (context, index) => FutureBuilder(
+            future: DefaultAssetBundle.of(context).loadString(_songPath(index)),
+            builder: (context, snapshot) {
+              if (!snapshot.hasData) {
+                return const ListTile();
+              }
+
+              final song = Song.fromJson(jsonDecode(snapshot.data.toString()));
+
+              return ListTile(
+                title: Text(song.title),
+              );
+            },
+          ),
+        ),
+      ),
     );
+  }
+
+  String _songPath(int index) {
+    return '${album.lyricsFolderPath}/${album.lyricsPaths[index]}';
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: lesserafim_lyrics
 description: A new Flutter project.
 # The following line prevents the package from being accidentally published to
 # pub.dev using `flutter pub publish`. This is preferred for private packages.
-publish_to: 'none' # Remove this line if you wish to publish to pub.dev
+publish_to: "none" # Remove this line if you wish to publish to pub.dev
 
 # The following defines the version and build number for your application.
 # A version number is three numbers separated by dots, like 1.2.43
@@ -19,7 +19,7 @@ publish_to: 'none' # Remove this line if you wish to publish to pub.dev
 version: 1.0.0+1
 
 environment:
-  sdk: '>=3.0.3 <4.0.0'
+  sdk: ">=3.0.3 <4.0.0"
 
 # Dependencies specify other packages that your package needs in order to work.
 # To automatically upgrade your package dependencies to the latest versions
@@ -30,7 +30,6 @@ environment:
 dependencies:
   flutter:
     sdk: flutter
-
 
   # The following adds the Cupertino Icons font to your application.
   # Use with the CupertinoIcons class for iOS style icons.
@@ -52,7 +51,6 @@ dev_dependencies:
 
 # The following section is specific to Flutter packages.
 flutter:
-
   # The following line ensures that the Material Icons font is
   # included with your application, so that you can use the icons in
   # the material Icons class.
@@ -90,3 +88,6 @@ flutter:
   # see https://flutter.dev/custom-fonts/#from-packages
   assets:
     - assets/
+    - assets/lyrics/fearless/
+    - assets/lyrics/antifragile/
+    - assets/lyrics/unforgiven/


### PR DESCRIPTION
- Created `Song` at `model/song.dart`.
- Added song titles to album page.
- Included song lyrics paths in `pubspec.yaml`.